### PR TITLE
Add golangci-lint to CI and fix errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,13 @@ jobs:
         #     /home/runner/work/_temp/fcd52edc-894a-48eb-bf93-f8b8d5752bce.sh: line 1: unexpected EOF while looking for matching `"'
         #
         run: $(go env GOPATH)/bin/golint -set_exit_status ./...
+
+  golangci-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Check: golangci-lint"
+        uses: golangci/golangci-lint-action@v2

--- a/context.go
+++ b/context.go
@@ -267,7 +267,7 @@ func (c *Context) Wait() []error {
 	c.Log.Debugf("Context Wait(); jobs queued: %v", len(c.Pool.Jobs))
 
 	c.Stats.LoopDuration =
-		c.Stats.LoopDuration + time.Now().Sub(c.Stats.lastLoopStart)
+		c.Stats.LoopDuration + time.Since(c.Stats.lastLoopStart)
 
 	defer func() {
 		// Reset the last loop start.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/yosssi/ace v0.0.5
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/russross/blackfriday.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSfrPzImPoVxuomtbT2nk=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/russross/blackfriday.v2 v2.0.0 h1:+FlnIV8DSQnT7NZ43hcVKcdJdzZoeCmJj4Ql8gq5keA=

--- a/modules/mtoc/mtoc.go
+++ b/modules/mtoc/mtoc.go
@@ -110,7 +110,6 @@ func buildTree(headers []*header) *html.Node {
 		if needNewListNode {
 			listItemNode = &html.Node{Data: "li", Type: html.ElementNode}
 			listNode.AppendChild(listItemNode)
-			needNewListNode = false
 		}
 
 		contentNode := &html.Node{Data: header.title, Type: html.TextNode}

--- a/modulir.go
+++ b/modulir.go
@@ -177,7 +177,7 @@ func build(c *Context, f func(*Context) []error,
 		// shut it back down.
 		c.Pool.Wait()
 
-		buildDuration := time.Now().Sub(c.Stats.Start)
+		buildDuration := time.Since(c.Stats.Start)
 
 		if lastRoundErrors != nil {
 			errors = append(errors, lastRoundErrors...)

--- a/pool.go
+++ b/pool.go
@@ -80,7 +80,6 @@ type Pool struct {
 
 	colorizer      *colorizer
 	concurrency    int
-	initialized    bool
 	jobsInternal   chan *Job
 	jobsErroredMu  sync.Mutex
 	jobsExecutedMu sync.Mutex
@@ -283,10 +282,7 @@ func (p *Pool) Wait() bool {
 	// Occasionally useful for debugging.
 	//p.logWaitTimeoutInfo()
 
-	if p.JobsErrored != nil {
-		return false
-	}
-	return true
+	return p.JobsErrored == nil
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -458,7 +454,7 @@ func (p *Pool) workJob(workerNum int, job *Job) {
 	start := time.Now()
 
 	defer func() {
-		job.Duration = time.Now().Sub(start)
+		job.Duration = time.Since(start)
 
 		// Kill the timeout Goroutine.
 		done <- struct{}{}


### PR DESCRIPTION
Adds golangci-lint to CI (for a slightly stricter error checker) and
fixes problems in the codebase.