### PR TITLE
Switch to `xerrors` for everything

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+linters:
+  enable:
+    - forbidigo
+
+linters-settings:
+  forbidigo:
+    forbid:
+      - '^errors\.Wrap$'
+      - '^errors\.Wrapf$'
+      - '^fmt\.Errorf$'

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,12 @@ require (
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml v1.6.0
-	github.com/pkg/errors v0.9.1
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/yosssi/ace v0.0.5
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
 	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/russross/blackfriday.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
@@ -40,7 +38,6 @@ gopkg.in/russross/blackfriday.v2 v2.0.0/go.mod h1:6sSBNz/GtOm/pJTuh5UmBK2ZHfmnxG
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/http.go
+++ b/http.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -48,7 +48,7 @@ func startServingTargetDirHTTP(c *Context, buildComplete *sync.Cond) *http.Serve
 		// ListenAndServe always returns a non-nil error (but if started
 		// successfully, it'll block for a long time).
 		if err != http.ErrServerClosed {
-			exitWithError(errors.Wrap(err, "Error starting HTTP server"))
+			exitWithError(xerrors.Errorf("error starting HTTP server: %w", err))
 		}
 	}()
 

--- a/modules/mace/mace.go
+++ b/modules/mace/mace.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/brandur/modulir"
-	"github.com/pkg/errors"
 	"github.com/yosssi/ace"
+	"golang.org/x/xerrors"
 )
 
 // Load loads an Ace template.
@@ -52,12 +52,12 @@ func Render(c *modulir.Context, basePath, innerPath string, writer io.Writer,
 
 	template, err := Load(c, basePath, innerPath, opts)
 	if err != nil {
-		return errors.Wrap(err, "Error loading template")
+		return xerrors.Errorf("error loading template: %w", err)
 	}
 
 	err = template.Execute(writer, locals)
 	if err != nil {
-		return errors.Wrap(err, "Error rendering template")
+		return xerrors.Errorf("error rendering template: %w", err)
 	}
 
 	c.Log.Debugf("mace: Rendered view '%s'", innerPath)
@@ -71,12 +71,12 @@ func RenderFile(c *modulir.Context, basePath, innerPath, target string,
 
 	template, err := Load(c, basePath, innerPath, opts)
 	if err != nil {
-		return errors.Wrap(err, "Error loading template")
+		return xerrors.Errorf("error loading template: %w", err)
 	}
 
 	file, err := os.Create(target)
 	if err != nil {
-		return errors.Wrap(err, "Error creating target file")
+		return xerrors.Errorf("error creating target file: %w", err)
 	}
 	defer file.Close()
 
@@ -85,7 +85,7 @@ func RenderFile(c *modulir.Context, basePath, innerPath, target string,
 
 	err = template.Execute(writer, locals)
 	if err != nil {
-		return errors.Wrap(err, "Error rendering template")
+		return xerrors.Errorf("error rendering template: %w", err)
 	}
 
 	c.Log.Debugf("mace: Rendered view '%s' to '%s'", innerPath, target)

--- a/modules/mfile/mfile.go
+++ b/modules/mfile/mfile.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/brandur/modulir"
 	gocache "github.com/patrickmn/go-cache"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -28,19 +28,19 @@ import (
 func CopyFile(c *modulir.Context, source, target string) error {
 	in, err := os.Open(source)
 	if err != nil {
-		return errors.Wrap(err, "Error opening copy source")
+		return xerrors.Errorf("error opening copy source: %w", err)
 	}
 	defer in.Close()
 
 	out, err := os.Create(target)
 	if err != nil {
-		return errors.Wrap(err, "Error creating copy target")
+		return xerrors.Errorf("error creating copy target: %w", err)
 	}
 	defer out.Close()
 
 	_, err = io.Copy(out, in)
 	if err != nil {
-		return errors.Wrap(err, "Error copying data")
+		return xerrors.Errorf("error copying data: %w", err)
 	}
 
 	c.Log.Debugf("mfile: Copied '%s' to '%s'", source, target)
@@ -57,7 +57,7 @@ func CopyFileToDir(c *modulir.Context, source, targetDir string) error {
 func EnsureDir(c *modulir.Context, target string) error {
 	err := os.MkdirAll(target, 0755)
 	if err != nil {
-		return errors.Wrap(err, "Error creating directory")
+		return xerrors.Errorf("error creating directory: %w", err)
 	}
 
 	c.Log.Debugf("mfile: Ensured dir existence: %s", target)
@@ -86,12 +86,12 @@ func EnsureSymlink(c *modulir.Context, source, target string) error {
 		goto create
 	}
 	if err != nil {
-		return errors.Wrap(err, "Error checking symlink")
+		return xerrors.Errorf("error checking symlink: %w", err)
 	}
 
 	actual, err = os.Readlink(target)
 	if err != nil {
-		return errors.Wrap(err, "Error reading symlink")
+		return xerrors.Errorf("error reading symlink: %w", err)
 	}
 
 	if actual == source {
@@ -104,7 +104,7 @@ func EnsureSymlink(c *modulir.Context, source, target string) error {
 create:
 	err = os.RemoveAll(target)
 	if err != nil {
-		return errors.Wrap(err, "Error removing symlink")
+		return xerrors.Errorf("error removing symlink: %w", err)
 	}
 
 	source, err = filepath.Abs(source)
@@ -119,7 +119,7 @@ create:
 
 	err = os.Symlink(source, target)
 	if err != nil {
-		return errors.Wrap(err, "Error creating symlink")
+		return xerrors.Errorf("error creating symlink: %w", err)
 	}
 
 	return nil
@@ -237,7 +237,7 @@ func ReadDirWithOptions(c *modulir.Context, source string,
 
 	infos, err := ioutil.ReadDir(source)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error reading directory")
+		return nil, xerrors.Errorf("error reading directory: %w", err)
 	}
 
 	var files []string

--- a/modules/mmarkdown/mmarkdown.go
+++ b/modules/mmarkdown/mmarkdown.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 
 	"github.com/brandur/modulir"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 	"gopkg.in/russross/blackfriday.v2"
 )
 
@@ -29,14 +29,14 @@ func Render(c *modulir.Context, data []byte) []byte {
 func RenderFile(c *modulir.Context, source, target string) error {
 	inData, err := ioutil.ReadFile(source)
 	if err != nil {
-		return errors.Wrap(err, "Error reading file")
+		return xerrors.Errorf("error reading file: %w", err)
 	}
 
 	outData := Render(c, inData)
 
 	err = ioutil.WriteFile(target, outData, 0644)
 	if err != nil {
-		return errors.Wrap(err, "Error writing file")
+		return xerrors.Errorf("error writing file: %w", err)
 	}
 
 	c.Log.Debugf("mmarkdown: Rendered '%s' to '%s'", source, target)

--- a/modules/mmarkdownext/mmarkdownext.go
+++ b/modules/mmarkdownext/mmarkdownext.go
@@ -12,7 +12,7 @@ import (
 	"text/template"
 
 	"github.com/brandur/modulir/modules/mtemplate"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 	"gopkg.in/russross/blackfriday.v2"
 )
 
@@ -173,7 +173,7 @@ func transformGoTemplate(source string, options *RenderOptions) (string, error) 
 
 	tmpl, err := template.New("fmarkdownTemp").Funcs(FuncMap).Parse(source)
 	if err != nil {
-		return "", errors.Wrap(err, "error parsing template")
+		return "", xerrors.Errorf("error parsing template: %w", err)
 	}
 
 	var templateData interface{}
@@ -185,7 +185,7 @@ func transformGoTemplate(source string, options *RenderOptions) (string, error) 
 	var b bytes.Buffer
 	err = tmpl.Execute(&b, templateData)
 	if err != nil {
-		return "", errors.Wrap(err, "error executing template")
+		return "", xerrors.Errorf("error executing template: %w", err)
 	}
 
 	// fmt.Printf("output in = %v ...\n", b.String())

--- a/modules/mtemplate/mtemplate.go
+++ b/modules/mtemplate/mtemplate.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	texttemplate "text/template"
 	"time"
+
+	"golang.org/x/xerrors"
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -61,7 +63,7 @@ func CombineFuncMaps(funcMaps ...template.FuncMap) template.FuncMap {
 	for _, fm := range funcMaps {
 		for k, v := range fm {
 			if _, ok := combined[k]; ok {
-				panic(fmt.Errorf("duplicate function map key on combine: %s", k))
+				panic(xerrors.Errorf("duplicate function map key on combine: %s", k))
 			}
 
 			combined[k] = v

--- a/modules/mtoc/mtoc.go
+++ b/modules/mtoc/mtoc.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"golang.org/x/net/html"
+	"golang.org/x/xerrors"
 )
 
 type header struct {
@@ -32,7 +32,7 @@ func RenderFromHTMLWithMaxLevel(content string, maxLevel int) (string, error) {
 	for _, match := range matches {
 		level, err := strconv.Atoi(match[1])
 		if err != nil {
-			return "", errors.Wrap(err, "Error extracting header level")
+			return "", xerrors.Errorf("error extracting header level: %w", err)
 		}
 
 		if maxLevel != -1 && level > maxLevel {

--- a/modules/mtoml/mtoml.go
+++ b/modules/mtoml/mtoml.go
@@ -2,24 +2,24 @@ package mtoml
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io/ioutil"
 
 	"github.com/brandur/modulir"
 	"github.com/pelletier/go-toml"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // ParseFile is a shortcut from parsing a source file as TOML.
 func ParseFile(c *modulir.Context, source string, v interface{}) error {
 	data, err := ioutil.ReadFile(source)
 	if err != nil {
-		return errors.Wrap(err, "Error reading file")
+		return xerrors.Errorf("error reading file: %w", err)
 	}
 
 	err = toml.Unmarshal(data, v)
 	if err != nil {
-		return errors.Wrap(err, "Error unmarshaling TOML")
+		return xerrors.Errorf("error unmarshaling TOML: %w", err)
 	}
 
 	c.Log.Debugf("mtoml: Parsed file: %s", source)
@@ -31,7 +31,7 @@ func ParseFile(c *modulir.Context, source string, v interface{}) error {
 func ParseFileFrontmatter(c *modulir.Context, source string, v interface{}) ([]byte, error) {
 	data, err := ioutil.ReadFile(source)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error reading file")
+		return nil, xerrors.Errorf("error reading file: %w", err)
 	}
 
 	frontmatter, content, err := splitFrontmatter(data)
@@ -41,7 +41,7 @@ func ParseFileFrontmatter(c *modulir.Context, source string, v interface{}) ([]b
 
 	err = toml.Unmarshal(frontmatter, v)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error unmarshaling TOML frontmatter")
+		return nil, xerrors.Errorf("error unmarshaling TOML frontmatter: %w", err)
 	}
 
 	c.Log.Debugf("mtoml: Parsed file frontmatter: %s", source)
@@ -52,7 +52,7 @@ func ParseFileFrontmatter(c *modulir.Context, source string, v interface{}) ([]b
 // Private
 //
 
-var errBadFrontmatter = fmt.Errorf("Unable to split TOML frontmatter")
+var errBadFrontmatter = errors.New("error splitting TOML frontmatter")
 
 func splitFrontmatter(data []byte) ([]byte, []byte, error) {
 	parts := bytes.Split(data, []byte("+++\n"))

--- a/modules/myaml/myaml.go
+++ b/modules/myaml/myaml.go
@@ -2,11 +2,11 @@ package myaml
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io/ioutil"
 
 	"github.com/brandur/modulir"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -14,12 +14,12 @@ import (
 func ParseFile(c *modulir.Context, source string, v interface{}) error {
 	raw, err := ioutil.ReadFile(source)
 	if err != nil {
-		return errors.Wrap(err, "Error reading file")
+		return xerrors.Errorf("error reading file: %w", err)
 	}
 
 	err = yaml.Unmarshal(raw, v)
 	if err != nil {
-		return errors.Wrap(err, "Error unmarshaling YAML")
+		return xerrors.Errorf("error unmarshaling YAML: %w", err)
 	}
 
 	c.Log.Debugf("myaml: Parsed file: %s", source)
@@ -31,7 +31,7 @@ func ParseFile(c *modulir.Context, source string, v interface{}) error {
 func ParseFileFrontmatter(c *modulir.Context, source string, v interface{}) ([]byte, error) {
 	data, err := ioutil.ReadFile(source)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error reading file")
+		return nil, xerrors.Errorf("error reading file: %w", err)
 	}
 
 	frontmatter, content, err := splitFrontmatter(data)
@@ -41,7 +41,7 @@ func ParseFileFrontmatter(c *modulir.Context, source string, v interface{}) ([]b
 
 	err = yaml.Unmarshal(frontmatter, v)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error unmarshaling YAML frontmatter")
+		return nil, xerrors.Errorf("error unmarshaling YAML frontmatter: %w", err)
 	}
 
 	c.Log.Debugf("myaml: Parsed file frontmatter: %s", source)
@@ -52,7 +52,7 @@ func ParseFileFrontmatter(c *modulir.Context, source string, v interface{}) ([]b
 // Private
 //
 
-var errBadFrontmatter = fmt.Errorf("Unable to split YAML frontmatter")
+var errBadFrontmatter = errors.New("error splitting YAML frontmatter")
 
 func splitFrontmatter(data []byte) ([]byte, []byte, error) {
 	parts := bytes.Split(data, []byte("---\n"))

--- a/modulir.go
+++ b/modulir.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -94,7 +94,7 @@ func BuildLoop(config *Config, f func(*Context) []error) {
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		exitWithError(errors.Wrap(err, "Error starting watcher"))
+		exitWithError(xerrors.Errorf("error starting watcher: %w", err))
 	}
 	defer watcher.Close()
 
@@ -246,7 +246,7 @@ func calculateTotalDuration(jobs []*Job) time.Duration {
 // instead of waiting for a build.
 func ensureTargetDir(c *Context) {
 	if err := os.MkdirAll(c.TargetDir, 0755); err != nil {
-		exitWithError(fmt.Errorf("Error creating target directory: %v", err))
+		exitWithError(xerrors.Errorf("error creating target directory: %w", err))
 	}
 }
 

--- a/modulir_test.go
+++ b/modulir_test.go
@@ -1,7 +1,5 @@
 package modulir
 
-import (
 //"testing"
 
 //assert "github.com/stretchr/testify/require"
-)

--- a/pool.go
+++ b/pool.go
@@ -1,12 +1,11 @@
 package modulir
 
 import (
-	"fmt"
 	"sort"
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -462,11 +461,11 @@ func (p *Pool) workJob(workerNum int, job *Job) {
 		var panicked bool
 		if r := recover(); r != nil {
 			if err, ok := r.(error); ok {
-				jobErr = errors.Wrap(err, "Job panicked")
+				jobErr = xerrors.Errorf("job panicked: %w", err)
 			} else {
 				// Panics are often just given a string to panic with, so make
 				// sure to handle that as well
-				jobErr = fmt.Errorf("Job panicked: %v", r)
+				jobErr = xerrors.Errorf("job panicked: %v", r)
 			}
 			panicked = true
 		}


### PR DESCRIPTION
More modern error conventions given that the `errors` package hasn't
been the way to go for a while.

See also: https://brandur.org/fragments/go-xerror