### PR TITLE
Helper for downloading larger images without separate TOML file

### DIFF
--- a/modules/mtemplate/mtemplate_test.go
+++ b/modules/mtemplate/mtemplate_test.go
@@ -1,7 +1,9 @@
 package mtemplate
 
 import (
+	"context"
 	"html/template"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -127,6 +129,56 @@ func TestDistanceOfTimeInWords(t *testing.T) {
 		DistanceOfTimeInWords(to.Add(mustParseDuration("-24h")*(365*3)), to))
 	assert.Equal(t, "10 years",
 		DistanceOfTimeInWords(to.Add(mustParseDuration("-24h")*(365*10)), to))
+}
+
+func TestDownloadedImage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("SetsContextAndEmitsPath", func(t *testing.T) {
+		ctx, downloadedImageContainer := DownloadedImageContext(ctx)
+
+		assert.Equal(t,
+			"/photographs/belize/01/kukumba-beach-1.jpg",
+			DownloadedImage(
+				ctx,
+				"/photographs/belize/01/kukumba-beach-1",
+				"https://www.dropbox.com/s/6fmtgs00c5xtevg/2W4A1500.JPG?dl=1",
+				1200,
+			),
+		)
+
+		assert.Equal(t,
+			[]*DownloadedImageInfo{
+				{
+					"/photographs/belize/01/kukumba-beach-1",
+					mustURL(t, "https://www.dropbox.com/s/6fmtgs00c5xtevg/2W4A1500.JPG?dl=1"),
+					1200,
+				},
+			},
+			downloadedImageContainer.Images,
+		)
+	})
+
+	t.Run("AlternateExtension", func(t *testing.T) {
+		ctx, _ := DownloadedImageContext(ctx)
+
+		assert.Equal(t,
+			"/photographs/diagram.png",
+			DownloadedImage(
+				ctx,
+				"/photographs/diagram",
+				"https://www.dropbox.com/s/6fmtgs00c5xtevg/2W4A1500.png?dl=1",
+				1200,
+			),
+		)
+	})
+}
+
+func mustURL(t *testing.T, s string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(s)
+	assert.NoError(t, err)
+	return u
 }
 
 func TestFigure(t *testing.T) {

--- a/modules/mtemplatemd/mtemplatemd_test.go
+++ b/modules/mtemplatemd/mtemplatemd_test.go
@@ -21,13 +21,10 @@ func TestIncludeMarkdown(t *testing.T) {
 	err = tmpfile.Close()
 	assert.NoError(t, err)
 
-	dependencies := map[string]struct{}{}
-	ctx := context.WithValue(context.Background(),
-		IncludeMarkdownDependencyKeys, dependencies)
+	ctx, container := Context(context.Background())
 
 	assert.Equal(t, `<p><strong>hello, world</strong></p>`,
-		strings.TrimSpace(string(includeMarkdown(ctx, tmpfile.Name()))))
+		strings.TrimSpace(string(IncludeMarkdown(ctx, tmpfile.Name()))))
 
-	_, ok := dependencies[tmpfile.Name()]
-	assert.True(t, ok)
+	assert.Contains(t, container.Dependencies, tmpfile.Name())
 }


### PR DESCRIPTION
Allows images to be specified inline in templates rather than in a
separate TOML file which is less work and faster.