### PR TITLE
Upgrade to golangci-lint v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Check: golangci-lint"
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.49
-
+          version: v2.0.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,48 +1,64 @@
+version: "2"
+
 linters:
+  default: all
+
   disable:
     # obnoxious
     - cyclop
+    - depguard
     - dupl
-    - exhaustivestruct
     - exhaustruct
     - forcetypeassert
     - funlen
-    - gochecknoinits
     - gochecknoglobals
+    - gochecknoinits
     - gocognit
     - gocyclo
     - godox
-    - gomnd
+    - mnd
     - nlreturn
     - paralleltest
     - testpackage
-    - wsl
     - varnamelen
+    - wsl
 
-    # deprecated
-    - golint
-    - interfacer
-    - maligned
-    - scopelint
-  enable-all: true
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: ^errors\.Wrap$
+        - pattern: ^errors\.Wrapf$
+        - pattern: ^fmt\.Errorf$
 
-linters-settings:
-  forbidigo:
-    forbid:
-      - '^errors\.Wrap$'
-      - '^errors\.Wrapf$'
-      - '^fmt\.Errorf$'
-  gci:
-    local-prefixes: github.com/brandur
+    gocritic:
+      disabled-checks:
+        - commentFormatting
 
-  gocritic:
-    disabled-checks:
-      - commentFormatting
+    gosec:
+      excludes:
+        - G203
 
-  gosec:
-    excludes:
-      - G203
+    wrapcheck:
+      ignore-package-globs:
+        - github.com/brandur/*
 
-  wrapcheck:
-    ignorePackageGlobs:
-      - github.com/brandur/*
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - Standard
+        - Default
+        - Prefix(github.com/brandur)

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,25 @@
 all: clean test vet check-gofmt lint
 
+.PHONY: check-gofmt
 check-gofmt:
 	scripts/check_gofmt.sh
 
+.PHONY: clean
 clean:
 	go clean ./...
 
+.PHONY: lint
 lint:
-	$(shell go env GOPATH)/bin/golint -set_exit_status ./...
+	golangci-lint run --fix
 
+.PHONY: test
 test:
 	go test ./... -test.v
 
+.PHONY: test-nocache
 test-nocache:
 	go test -count=1 ./...
 
+.PHONY: vet
 vet:
 	go vet ./...

--- a/http.go
+++ b/http.go
@@ -97,7 +97,7 @@ var websocketJSTemplate = template.Must(template.New("websocket.js").Parse(webso
 // Part of the Gorilla websocket infrastructure that upgrades HTTP connections
 // to websocket connections when we see an incoming websocket request.
 var websocketUpgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool {
+	CheckOrigin: func(*http.Request) bool {
 		// Thought about doing localhost only, but it may cause trouble for
 		// something eventually. If end user can connect to the web page,
 		// assume they're also safe for websockets.
@@ -124,7 +124,7 @@ func getWebsocketHandler(c *Context, buildComplete *sync.Cond) func(w http.Respo
 }
 
 func getWebsocketJSHandler(c *Context) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/javascript")
 		err := websocketJSTemplate.Execute(w, map[string]interface{}{
 			"Port": c.Port,

--- a/modules/mimage/mimage.go
+++ b/modules/mimage/mimage.go
@@ -172,7 +172,7 @@ func ResizeImage(c *modulir.Context,
 
 	// After everything is done, created a marker file to indicate that the
 	// work doesn't need to be redone.
-	file, err := os.OpenFile(markerPath, os.O_RDONLY|os.O_CREATE, 0o755) //nolint:nosnakecase
+	file, err := os.OpenFile(markerPath, os.O_RDONLY|os.O_CREATE, 0o755)
 	if err != nil {
 		return true, xerrors.Errorf("error creating marker for image '%s': %w", targetSlug, err)
 	}

--- a/modules/mimage/mimage_test.go
+++ b/modules/mimage/mimage_test.go
@@ -26,7 +26,7 @@ func TestResizeImageJPEG(t *testing.T) {
 	d, _ := os.Getwd()
 	t.Logf("pwd = %v\n", d)
 
-	tmpfile, err := os.CreateTemp("", "resized_image_jpeg")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "resized_image_jpeg")
 	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -45,7 +45,7 @@ func TestResizeImageJPEG_NoMozJPEG(t *testing.T) {
 	d, _ := os.Getwd()
 	t.Logf("pwd = %v\n", d)
 
-	tmpfile, err := os.CreateTemp("", "resized_image_jpeg_no_mozjpeg")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "resized_image_jpeg_no_mozjpeg")
 	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -63,7 +63,7 @@ func TestResizeImagePNG(t *testing.T) {
 	d, _ := os.Getwd()
 	t.Logf("pwd = %v\n", d)
 
-	tmpfile, err := os.CreateTemp("", "resized_image_png")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "resized_image_png")
 	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -82,7 +82,7 @@ func TestResizeImagePNG_NoPNGQuant(t *testing.T) {
 	d, _ := os.Getwd()
 	t.Logf("pwd = %v\n", d)
 
-	tmpfile, err := os.CreateTemp("", "resized_image_png_no_pngquant")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "resized_image_png_no_pngquant")
 	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 

--- a/modules/mmarkdown/mmarkdown.go
+++ b/modules/mmarkdown/mmarkdown.go
@@ -21,7 +21,7 @@ import (
 
 // Render is a shortcut for rendering some source data to Markdown via Black
 // Friday.
-func Render(c *modulir.Context, data []byte) []byte {
+func Render(_ *modulir.Context, data []byte) []byte {
 	return blackfriday.Run(data)
 }
 

--- a/modules/mmarkdownext/mmarkdownext.go
+++ b/modules/mmarkdownext/mmarkdownext.go
@@ -130,7 +130,7 @@ func collapseHTML(html string) string {
 
 var codeRE = regexp.MustCompile(`<code class="(\w+)">`)
 
-func transformCodeWithLanguagePrefix(source string, options *RenderOptions) (string, error) {
+func transformCodeWithLanguagePrefix(source string, _ *RenderOptions) (string, error) {
 	return codeRE.ReplaceAllString(source, `<code class="language-$1">`), nil
 }
 
@@ -143,7 +143,7 @@ const figureHTML = `
 
 var figureRE = regexp.MustCompile(`!fig src="(.*)" caption="(.*)"`)
 
-func transformFigures(source string, options *RenderOptions) (string, error) {
+func transformFigures(source string, _ *RenderOptions) (string, error) {
 	return figureRE.ReplaceAllStringFunc(source, func(figure string) string {
 		matches := figureRE.FindStringSubmatch(figure)
 		src := matches[1]
@@ -390,13 +390,9 @@ func transformImagesAndLinksToAbsoluteURLs(source string, options *RenderOptions
 		return source, nil
 	}
 
-	source = relativeImageRE.ReplaceAllStringFunc(source, func(img string) string {
-		return `<img src="` + options.AbsoluteURL + `/`
-	})
+	source = relativeImageRE.ReplaceAllString(source, `<img src="`+options.AbsoluteURL+`/`)
 
-	source = relativeLinkRE.ReplaceAllStringFunc(source, func(img string) string {
-		return `<a href="` + options.AbsoluteURL + `/`
-	})
+	source = relativeLinkRE.ReplaceAllString(source, `<a href="`+options.AbsoluteURL+`/`)
 
 	return source, nil
 }
@@ -409,6 +405,6 @@ func transformLinksToNoFollow(source string, options *RenderOptions) (string, er
 	}
 
 	return absoluteLinkRE.ReplaceAllStringFunc(source, func(link string) string {
-		return fmt.Sprintf(`%s rel="nofollow"`, link)
+		return link + " rel=\"nofollow\""
 	}), nil
 }

--- a/modules/mtemplate/mtemplate.go
+++ b/modules/mtemplate/mtemplate.go
@@ -105,32 +105,32 @@ const (
 func DistanceOfTimeInWords(to, from time.Time) string {
 	d := from.Sub(to)
 
-	min := int(round(d.Minutes()))
+	minutes := int(round(d.Minutes()))
 
 	switch {
-	case min == 0:
+	case minutes == 0:
 		return "less than 1 minute"
-	case min == 1:
-		return fmt.Sprintf("%d minute", min)
-	case min >= 1 && min <= 44:
-		return fmt.Sprintf("%d minutes", min)
-	case min >= 45 && min <= 89:
+	case minutes == 1:
+		return fmt.Sprintf("%d minute", minutes)
+	case minutes >= 1 && minutes <= 44:
+		return fmt.Sprintf("%d minutes", minutes)
+	case minutes >= 45 && minutes <= 89:
 		return "about 1 hour"
-	case min >= 90 && min <= minutesInDay-1:
+	case minutes >= 90 && minutes <= minutesInDay-1:
 		return fmt.Sprintf("about %d hours", int(round(d.Hours())))
-	case min >= minutesInDay && min <= minutesInDay*2-1:
+	case minutes >= minutesInDay && minutes <= minutesInDay*2-1:
 		return "about 1 day"
-	case min >= 2520 && min <= minutesInMonth-1:
+	case minutes >= 2520 && minutes <= minutesInMonth-1:
 		return fmt.Sprintf("%d days", int(round(d.Hours()/24.0)))
-	case min >= minutesInMonth && min <= minutesInMonth*2-1:
+	case minutes >= minutesInMonth && minutes <= minutesInMonth*2-1:
 		return "about 1 month"
-	case min >= minutesInMonth*2 && min <= minutesInYear-1:
+	case minutes >= minutesInMonth*2 && minutes <= minutesInYear-1:
 		return fmt.Sprintf("%d months", int(round(d.Hours()/24.0/30.0)))
-	case min >= minutesInYear && min <= minutesInYear+3*minutesInMonth-1:
+	case minutes >= minutesInYear && minutes <= minutesInYear+3*minutesInMonth-1:
 		return "about 1 year"
-	case min >= minutesInYear+3*minutesInMonth-1 && min <= minutesInYear+9*minutesInMonth-1:
+	case minutes >= minutesInYear+3*minutesInMonth-1 && minutes <= minutesInYear+9*minutesInMonth-1:
 		return "over 1 year"
-	case min >= minutesInYear+9*minutesInMonth && min <= minutesInYear*2-1:
+	case minutes >= minutesInYear+9*minutesInMonth && minutes <= minutesInYear*2-1:
 		return "almost 2 years"
 	}
 

--- a/modules/mtemplatemd/mtemplatemd_test.go
+++ b/modules/mtemplatemd/mtemplatemd_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestIncludeMarkdown(t *testing.T) {
 	content := []byte("**hello, world**")
-	tmpfile, err := os.CreateTemp("", "markdown_sample.md")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "markdown_sample.md")
 	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 

--- a/modules/mtesting/mtesting.go
+++ b/modules/mtesting/mtesting.go
@@ -20,7 +20,7 @@ func NewContext() *modulir.Context {
 func WriteTempFile(t *testing.T, data []byte) string {
 	t.Helper()
 
-	tempFile, err := os.CreateTemp("", "modulir")
+	tempFile, err := os.CreateTemp(t.TempDir(), "modulir")
 	assert.NoError(t, err)
 
 	_, err = tempFile.Write(data)

--- a/modules/mtoc/mtoc_test.go
+++ b/modules/mtoc/mtoc_test.go
@@ -197,7 +197,7 @@ func TestRenderFromHTML_Basic(t *testing.T) {
 func TestRenderFromHTML_Empty(t *testing.T) {
 	rendered, err := RenderFromHTML("hello")
 	assert.NoError(t, err)
-	assert.Equal(t, "", rendered)
+	assert.Empty(t, rendered)
 }
 
 func TestRenderFromHTML_OtherAttrs(t *testing.T) {

--- a/modules/mtoml/mtoml_test.go
+++ b/modules/mtoml/mtoml_test.go
@@ -38,7 +38,7 @@ other`))
 		var v testStruct
 		content, err := ParseFileFrontmatter(c, path, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "", v.Foo)
+		assert.Empty(t, v.Foo)
 		assert.Equal(t, []byte("other"), content)
 	}
 

--- a/modules/myaml/myaml_test.go
+++ b/modules/myaml/myaml_test.go
@@ -38,7 +38,7 @@ other`))
 		var v testStruct
 		content, err := ParseFileFrontmatter(c, path, &v)
 		assert.NoError(t, err)
-		assert.Equal(t, "", v.Foo)
+		assert.Empty(t, v.Foo)
 		assert.Equal(t, []byte("other"), content)
 	}
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -13,9 +13,9 @@ func TestEmptyPool(t *testing.T) {
 	p.StartRound(0)
 	p.Wait()
 
-	assert.Equal(t, 0, len(p.JobsAll))
-	assert.Equal(t, 0, len(p.JobsErrored))
-	assert.Equal(t, 0, len(p.JobsExecuted))
+	assert.Empty(t, p.JobsAll)
+	assert.Empty(t, p.JobsErrored)
+	assert.Empty(t, p.JobsExecuted)
 	assert.Equal(t, []error(nil), p.JobErrors())
 }
 
@@ -32,18 +32,18 @@ func TestWithWork(t *testing.T) {
 	p.Wait()
 
 	// Check state on the pool
-	assert.Equal(t, 3, len(p.JobsAll))
-	assert.Equal(t, 0, len(p.JobsErrored))
-	assert.Equal(t, 2, len(p.JobsExecuted)) // Number of `return true` above
+	assert.Len(t, p.JobsAll, 3)
+	assert.Empty(t, p.JobsErrored)
+	assert.Len(t, p.JobsExecuted, 2) // Number of `return true` above
 	assert.Equal(t, []error(nil), p.JobErrors())
 
 	// Check state on individual jobs
-	assert.Equal(t, true, j0.Executed)
-	assert.Equal(t, nil, j0.Err)
-	assert.Equal(t, true, j1.Executed)
-	assert.Equal(t, nil, j1.Err)
-	assert.Equal(t, false, j2.Executed)
-	assert.Equal(t, nil, j2.Err)
+	assert.True(t, j0.Executed)
+	assert.NoError(t, j0.Err)
+	assert.True(t, j1.Executed)
+	assert.NoError(t, j1.Err)
+	assert.False(t, j2.Executed)
+	assert.NoError(t, j2.Err)
 }
 
 // Tests the pool with lots of fast jobs that do nothing across multiple
@@ -62,9 +62,9 @@ func TestWithLargeNonWork(t *testing.T) {
 		p.Wait()
 
 		// Check state on the pool
-		assert.Equal(t, numJobs, len(p.JobsAll))
-		assert.Equal(t, 0, len(p.JobsErrored))
-		assert.Equal(t, 0, len(p.JobsExecuted)) // Number of `return true` above
+		assert.Len(t, p.JobsAll, numJobs)
+		assert.Empty(t, p.JobsErrored)
+		assert.Empty(t, p.JobsExecuted) // Number of `return true` above
 		assert.Equal(t, []error(nil), p.JobErrors())
 	}
 }
@@ -82,17 +82,17 @@ func TestWithError(t *testing.T) {
 	p.Wait()
 
 	// Check state on the pool
-	assert.Equal(t, 3, len(p.JobsAll))
-	assert.Equal(t, 1, len(p.JobsErrored))
-	assert.Equal(t, 3, len(p.JobsExecuted)) // Number of `return true` above
+	assert.Len(t, p.JobsAll, 3)
+	assert.Len(t, p.JobsErrored, 1)
+	assert.Len(t, p.JobsExecuted, 3) // Number of `return true` above
 	assert.Equal(t, []string{"error"}, errorStrings(p.JobErrors()))
 
 	// Check state on individual jobs
-	assert.Equal(t, true, j0.Executed)
-	assert.Equal(t, nil, j0.Err)
-	assert.Equal(t, true, j1.Executed)
-	assert.Equal(t, nil, j1.Err)
-	assert.Equal(t, true, j2.Executed)
+	assert.True(t, j0.Executed)
+	assert.NoError(t, j0.Err)
+	assert.True(t, j1.Executed)
+	assert.NoError(t, j1.Err)
+	assert.True(t, j2.Executed)
 	assert.Equal(t, "error", j2.Err.Error())
 }
 
@@ -113,11 +113,11 @@ func TestWorkJob(t *testing.T) {
 
 	assert.True(t, executed)
 
-	assert.Equal(t, 0, len(p.JobsErrored))
-	assert.Equal(t, 1, len(p.JobsExecuted))
+	assert.Empty(t, p.JobsErrored)
+	assert.Len(t, p.JobsExecuted, 1)
 
-	assert.Equal(t, true, j.Executed)
-	assert.Equal(t, nil, j.Err)
+	assert.True(t, j.Executed)
+	assert.NoError(t, j.Err)
 }
 
 func TestWorkJob_Error(t *testing.T) {
@@ -137,11 +137,11 @@ func TestWorkJob_Error(t *testing.T) {
 
 	assert.True(t, executed)
 
-	assert.Equal(t, 1, len(p.JobsErrored))
-	assert.Equal(t, 1, len(p.JobsExecuted))
+	assert.Len(t, p.JobsErrored, 1)
+	assert.Len(t, p.JobsExecuted, 1)
 	assert.Equal(t, []string{"error"}, errorStrings(p.JobErrors()))
 
-	assert.Equal(t, true, j.Executed)
+	assert.True(t, j.Executed)
 	assert.Equal(t, "error", j.Err.Error())
 }
 
@@ -162,13 +162,13 @@ func TestWorkJob_Panic(t *testing.T) {
 
 	assert.True(t, executed)
 
-	assert.Equal(t, 1, len(p.JobsErrored))
-	assert.Equal(t, 0, len(p.JobsExecuted))
+	assert.Len(t, p.JobsErrored, 1)
+	assert.Empty(t, p.JobsExecuted)
 
 	err := p.JobErrors()[0]
 	assert.Equal(t, "job panicked: error", err.Error())
 
-	assert.Equal(t, false, j.Executed)
+	assert.False(t, j.Executed)
 	assert.Equal(t, "job panicked: error", j.Err.Error())
 }
 
@@ -189,11 +189,11 @@ func TestWorkJob_PanicString(t *testing.T) {
 
 	assert.True(t, executed)
 
-	assert.Equal(t, 1, len(p.JobsErrored))
-	assert.Equal(t, 0, len(p.JobsExecuted))
+	assert.Len(t, p.JobsErrored, 1)
+	assert.Empty(t, p.JobsExecuted)
 	assert.Equal(t, []string{"job panicked: error"}, errorStrings(p.JobErrors()))
 
-	assert.Equal(t, false, j.Executed)
+	assert.False(t, j.Executed)
 	assert.Equal(t, "job panicked: error", j.Err.Error())
 }
 

--- a/watch.go
+++ b/watch.go
@@ -63,11 +63,7 @@ func watchChanges(c *Context, watchEvents chan fsnotify.Event, watchErrors chan 
 			//
 			// The overwhelmingly common case will be few files being changed,
 			// and therefore the inner for almost never needs to loop.
-			for {
-				if len(changedSources) < 1 {
-					break
-				}
-
+			for len(changedSources) >= 1 {
 				// If the detect changes are identical to the last set of
 				// changes we just processed and we're within a certain quiesce
 				// time, *don't* trigger another rebuild and just go back to

--- a/watch_test.go
+++ b/watch_test.go
@@ -70,16 +70,16 @@ func TestCompareKeys(t *testing.T) {
 
 func TestShouldRebuild(t *testing.T) {
 	// Most things signal a rebuild
-	assert.Equal(t, true, shouldRebuild("a/path", fsnotify.Create))
-	assert.Equal(t, true, shouldRebuild("a/path", fsnotify.Remove))
-	assert.Equal(t, true, shouldRebuild("a/path", fsnotify.Write))
+	assert.True(t, shouldRebuild("a/path", fsnotify.Create))
+	assert.True(t, shouldRebuild("a/path", fsnotify.Remove))
+	assert.True(t, shouldRebuild("a/path", fsnotify.Write))
 
 	// With just a few special cases that don't
-	assert.Equal(t, false, shouldRebuild("a/path", fsnotify.Chmod))
-	assert.Equal(t, false, shouldRebuild("a/path", fsnotify.Rename))
-	assert.Equal(t, false, shouldRebuild("a/.DS_Store", fsnotify.Create))
-	assert.Equal(t, false, shouldRebuild("a/4913", fsnotify.Create))
-	assert.Equal(t, false, shouldRebuild("a/path~", fsnotify.Create))
+	assert.False(t, shouldRebuild("a/path", fsnotify.Chmod))
+	assert.False(t, shouldRebuild("a/path", fsnotify.Rename))
+	assert.False(t, shouldRebuild("a/.DS_Store", fsnotify.Create))
+	assert.False(t, shouldRebuild("a/4913", fsnotify.Create))
+	assert.False(t, shouldRebuild("a/path~", fsnotify.Create))
 }
 
 func TestWatchChanges(t *testing.T) {


### PR DESCRIPTION
Upgrade to golangci-lint v2, released yesterday. Mostly involves a
restructuring of the configuration file.