### PR TITLE
Only run CI on pull requests and merges to `master`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ env:
 on:
   pull_request:
   push:
+    branches:
+      - master
   schedule:
     # ever day at 8 AM
     - cron: "0 8 * * *"


### PR DESCRIPTION
Switch to the same set up as sorg so that we don't have doubled up
builds on pull requests. CI runs on pull requests, but not on branches
unless that branch is the `master` branch.